### PR TITLE
Update routes.json

### DIFF
--- a/plugins/rest-api-endpoints/routes.json
+++ b/plugins/rest-api-endpoints/routes.json
@@ -4877,7 +4877,7 @@
       "url": "/projects/columns/:column_id"
     }
   },
-  "pullRequests": {
+  "pulls": {
     "checkIfMerged": {
       "method": "GET",
       "params": {

--- a/test/issues/841-head-request-test.js
+++ b/test/issues/841-head-request-test.js
@@ -24,7 +24,7 @@ describe('https://github.com/octokit/rest.js/issues/841', () => {
       baseUrl: 'https://head-request-test.com'
     })
 
-    client.pullRequests.get({
+    client.pulls.get({
       method: 'head',
       owner: 'whatwg',
       repo: 'html',
@@ -32,7 +32,7 @@ describe('https://github.com/octokit/rest.js/issues/841', () => {
     })
 
       .then(() => {
-        return client.pullRequests.get({
+        return client.pulls.get({
           method: 'head',
           owner: 'whatwg',
           repo: 'html',


### PR DESCRIPTION
In v16.0.0 it the types said that `pullRequest` didn't exists and `pulls` does. When running the code this wasn't the case. Changing this fixed it.
